### PR TITLE
Add tests using Cucumber (Godog)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,9 @@ jobs:
       # Normally, this step would be in a custom primary image;
       # we've added it here for the sake of explanation.
       - run: go get github.com/tendermint/abci/cmd/abci-cli
+      - run: go get github.com/DATA-DOG/godog/cmd/godog
 
-      # @todo #22 Add test commands here
+      - run: (cd apitest && godog)
 
       - store_artifacts:
           path: /tmp/test-results

--- a/apitest/api_test.go
+++ b/apitest/api_test.go
@@ -1,0 +1,73 @@
+package apitest
+
+import (
+	"fmt"
+
+	"github.com/DATA-DOG/godog"
+)
+
+type apiFeature struct {
+	relyingParty RelyingParty
+	responses    []SendRequestAsyncResult
+}
+
+func (a *apiFeature) iCallTheSendRequestAPI() error {
+	a.iCallTheSendRequestAPIWithReferenceID("meow")
+	return nil
+}
+
+func (a *apiFeature) iShouldGetARequestID() error {
+	if len(a.responses[0].RequestID) == 0 {
+		return fmt.Errorf("Did not get a request ID")
+	}
+	return nil
+}
+
+func (a *apiFeature) iCallTheSendRequestAPIWithReferenceID(referenceID string) error {
+	params := SendRequestAsyncParams{referenceID}
+	response := a.relyingParty.SendRequestAsync(params)
+	a.responses = append(a.responses, response)
+	return nil
+}
+
+func (a *apiFeature) receivedRequestIDsShouldBeTheSame() error {
+	if len(a.responses) != 2 {
+		return fmt.Errorf("Expected 2 responses but got %d", len(a.responses))
+	}
+	if a.responses[0].RequestID != a.responses[1].RequestID {
+		return fmt.Errorf(
+			"Expected the two response IDs to be the same ('%s' != '%s')",
+			a.responses[0].RequestID,
+			a.responses[1].RequestID,
+		)
+	}
+	return nil
+}
+
+func (a *apiFeature) receivedRequestIDsShouldBeDifferent() error {
+	if len(a.responses) != 2 {
+		return fmt.Errorf("Expected 2 responses but got %d", len(a.responses))
+	}
+	if a.responses[0].RequestID == a.responses[1].RequestID {
+		return fmt.Errorf(
+			"Expected the two response IDs to be the different (both are '%s')",
+			a.responses[0].RequestID,
+		)
+	}
+	return nil
+}
+
+func (a *apiFeature) reset(_ interface{}) {
+	a.relyingParty = NewMockRelyingParty()
+	a.responses = []SendRequestAsyncResult{}
+}
+
+func FeatureContext(s *godog.Suite) {
+	api := &apiFeature{}
+	s.BeforeScenario(api.reset)
+	s.Step(`^I call the send request API$`, api.iCallTheSendRequestAPI)
+	s.Step(`^I should get a request ID$`, api.iShouldGetARequestID)
+	s.Step(`^I call the send request API with reference ID "([^"]*)"$`, api.iCallTheSendRequestAPIWithReferenceID)
+	s.Step(`^received request IDs should be the same$`, api.receivedRequestIDsShouldBeTheSame)
+	s.Step(`^received request IDs should be different$`, api.receivedRequestIDsShouldBeDifferent)
+}

--- a/apitest/features/Authentication.feature
+++ b/apitest/features/Authentication.feature
@@ -1,0 +1,20 @@
+Feature: Authentication
+  As a relying party
+  I want to authenticate the user's identity
+
+  @mock_rp
+  Scenario: Getting a request ID
+    When I call the send request API
+    Then I should get a request ID
+
+  @mock_rp
+  Scenario: Calling the send_request_to_id API twice with same reference ID
+    When I call the send request API with reference ID "e3cb44c9-8848-4dec-98c8-8083f373b1f7"
+    And I call the send request API with reference ID "e3cb44c9-8848-4dec-98c8-8083f373b1f7"
+    Then received request IDs should be the same
+
+  @mock_rp
+  Scenario: Calling the send_request_to_id API twice with different reference ID
+    When I call the send request API with reference ID "ee2a741b-056c-446f-bf4c-a73c0af29ed0"
+    And I call the send request API with reference ID "ddcaf9ae-a6ac-4bf9-ba9c-ce2e75601077"
+    Then received request IDs should be different

--- a/apitest/relying_party.go
+++ b/apitest/relying_party.go
@@ -1,0 +1,40 @@
+package apitest
+
+import "fmt"
+
+// RelyingParty represents a RP
+type RelyingParty interface {
+	SendRequestAsync(params SendRequestAsyncParams) SendRequestAsyncResult
+}
+
+// SendRequestAsyncResult is the result of calling a send_request_async
+type SendRequestAsyncResult struct {
+	RequestID string
+}
+
+// SendRequestAsyncParams represents SendRequestAsync parameters
+type SendRequestAsyncParams struct {
+	ReferenceID string
+}
+
+type mockRelyingParty struct {
+	requestIDMap map[string]string
+}
+
+// NewMockRelyingParty creates a mock relying party
+// that doesn't actually make any request to any server
+func NewMockRelyingParty() RelyingParty {
+	m := new(mockRelyingParty)
+	m.requestIDMap = make(map[string]string)
+	return m
+}
+
+// Performs a fake async request
+func (m *mockRelyingParty) SendRequestAsync(params SendRequestAsyncParams) SendRequestAsyncResult {
+	requestID := m.requestIDMap[params.ReferenceID]
+	if requestID == "" {
+		requestID = fmt.Sprintf("req%d", len(m.requestIDMap))
+		m.requestIDMap[params.ReferenceID] = requestID
+	}
+	return SendRequestAsyncResult{requestID}
+}


### PR DESCRIPTION
- Godog is a Cucumber implementation for go.
- Using Cucumber allows us to specify the system in high-level terms.
- I made `apitest` folder separate from `abci` and `api` folder so that the test is independent of actual API. But keep in same repository for ease of development.